### PR TITLE
Add napari logo and remove irrelevant bullet point

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
             </div>
             <h1
                 class="font-bold col-span-full mb-6 screen-495:mb-12 screen-1425:col-start-2 screen-1425:col-span-3 AppBarLanding_heading__ozOI5">
-                Discover, and share napari plugins</h1>
+                Discover and share napari plugins</h1>
             <div
                 class="grid grid-cols-[min-content,1fr] gap-sds-xl screen-655:gap-12 col-span-2 screen-875:col-span-3 screen-1425:col-start-2 items-center">
                 <svg


### PR DESCRIPTION
This PR updates the header bar to make it more napari-ifed. It:

- replaces the original graphic with the napari logo
- removes the 'learn how to install into napari' bullet point, since we don't actually provide that info
- removes 'install' from the heading, for the same reason

I think it looks pretty neat!

![image](https://github.com/user-attachments/assets/df708fde-1f89-464c-aadb-9bad56e87c3c)
