### PR TITLE
Make heading fit on one line

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
             </div>
             <h1
                 class="font-bold col-span-full mb-6 screen-495:mb-12 screen-1425:col-start-2 screen-1425:col-span-3 AppBarLanding_heading__ozOI5">
-                Discover and share napari plugins</h1>
+                Explore napari plugins</h1>
             <div
                 class="grid grid-cols-[min-content,1fr] gap-sds-xl screen-655:gap-12 col-span-2 screen-875:col-span-3 screen-1425:col-start-2 items-center">
                 <svg


### PR DESCRIPTION
Small PR to make the heading fit on one line. We really don't get a lot of characters for this, so I think either `Explore` or `Discover` are our only options, but it's gotta be one word. I tried `Find & share` which was the shortest thing I could think of that includes both concepts, but no dice.

![image](https://github.com/user-attachments/assets/02284073-4c8e-4c62-967f-dc4475e674d9)
