### PR TITLE
Fix bug with parsing project URLs

### DIFF
--- a/fetch_napari_data.py
+++ b/fetch_napari_data.py
@@ -141,7 +141,7 @@ def expand_proj_url(plugin_data: dict) -> None:
 
     # If urls do not exist, we try using the 'home_page' key (like in the old metadata spec).
     if not urls and "home_page" in plugin_data:
-        urls = f"homepage, {plugin_data['home_page']}"
+        urls = [f"homepage, {plugin_data['home_page']}"]
 
     plugin_data["home_github"] = ""
     plugin_data["home_other"] = ""


### PR DESCRIPTION
In #84 I introduced a bug with parsing the URLs for plugins that don't declare a `project_url` field but use the old `homepage` spec. This PR fixes that bug.

@willingc I'm pretty sure this closes #91 but I guess we'll have to deploy to be certain :roll_eyes: