### PR TITLE
Fix failing linting action

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -27,7 +27,7 @@ jobs:
           locked: true
 
       - name: Run pre-commit hooks
-        run: pixi run -e dev prek run --all-files
+        run: pixi run prek run --all-files
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Description



The linting action is failing because it points to an environment which does not exist.

We just use the default environment here because it contains the dev group (intentionally)



```



\##\[debug]Evaluating condition for step: 'Run pre-commit hooks'

\##\[debug]Evaluating: success()

\##\[debug]Evaluating success:

\##\[debug]=> true

\##\[debug]Result: true

\##\[debug]Starting: Run pre-commit hooks

\##\[debug]Loading inputs

\##\[debug]Loading env

Run pixi run -e dev prek run --all-files

&#x20; pixi run -e dev prek run --all-files

&#x20; shell: /usr/bin/bash -e {0}

\##\[debug]/usr/bin/bash -e /home/runner/work/\_temp/be704da1-129a-4319-99c2-7fecec752277.sh

Error:   × unknown environment 'dev'



Error: Process completed with exit code 1.

\##\[debug]Finishing: Run pre-commit hooks



```

