### PR TITLE
Fix plugin README overflow

### DIFF
--- a/templates/each_plugin_template.html
+++ b/templates/each_plugin_template.html
@@ -203,7 +203,7 @@
                                     class="flex flex-col text-xs mt-sds-xl mb-sds-l screen-495:mb-sds-xl gap-sds-m screen-495:gap-sds-l">
                                 </div>
                                 <div class="flex items-center justify-between mb-sds-xxl">
-                                    <div class="Markdown_markdown__QZ95j" data-pagefind-meta="package_metadata_description">
+                                    <div class="Markdown_markdown__QZ95j w-full" data-pagefind-meta="package_metadata_description">
 
                                         ${package_metadata_description}
 


### PR DESCRIPTION
Some plugins like [napari-nuclephaser](https://napari-hub.org/plugins/napari-nuclephaser.html) overflow the plugin page:

<img width="1852" height="1030" alt="Image" src="https://github.com/user-attachments/assets/d3bb3f06-cf58-489c-80e0-d6ec8c5ecd25" />

This fixes that. It causes very wide code blocks to scroll, but this seems better than everything overflowing.