### PR TITLE
Separate homepage browse sort from pagefind results

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
                                 <link href="/pagefind/pagefind-component-ui.css" rel="stylesheet">
                                 <script src="/pagefind/pagefind-component-ui.js" type="module"></script>
 
-                                <pagefind-config faceted preload></pagefind-config>
+                                <pagefind-config faceted></pagefind-config>
                                 <pagefind-input placeholder="Search for a plugin by keyword or author" autofocus="true" class="w-full"></pagefind-input>
                         </div>
                     </div>
@@ -90,13 +90,13 @@
                         <section class="col-span-2 screen-1425:col-span-3 space-y-sds-xl">
                             <div class="flex justify-between">
                                 <h2 class="flex items-center font-bold text-xl">
-                                  Browse plugins: <span class="p-2" id="pluginCount">
-                                      <pagefind-summary class="flex items-center font-bold text-xl"></pagefind-summary>
-                                  </span>
+                                  Browse plugins: <span class="p-2" id="pluginCount"></span>
                                 </h2>
                             </div>
                             <div class="flex flex-col justify-center"
                                 id="pluginContainer">
+                                <div id="staticBrowse"></div>
+                                <div id="pfResults" style="display:none">
                                 <pagefind-results>
                                     <script type="text/pagefind-template">
                                             <a class="searchResult py-sds-xl border-black border-t-2 last:border-b-2 hover:bg-hub-gray-100 w-full" data-testid="pluginSearchResult" href="{{ url | safeUrl }}">
@@ -173,6 +173,7 @@
                                             </a>
                                     </script>
                                 </pagefind-results>
+                                </div>
                             </div>
                         </section>
                     </div>
@@ -203,6 +204,8 @@
             </div>
 
     </div>
+
+    <script type="module" src="./static/js/browse_toggle.js"></script>
 </body>
 
 </html>

--- a/static/js/browse_toggle.js
+++ b/static/js/browse_toggle.js
@@ -1,0 +1,61 @@
+/**
+ * Sorted static browse + Pagefind component search.
+ *
+ * The default "Browse plugins" view is the pre-generated `plugins_list.html`,
+ * sorted by `last_updated` (descending). Searching uses the Pagefind component
+ * UI (`<pagefind-input>` + `<pagefind-results>`) with native relevance
+ * ranking. `faceted` without `preload` keeps the component results empty and
+ * defers loading Pagefind's WASM + index until the first search, so the
+ * homepage renders instantly from the static list.
+ */
+
+const PLUGIN_COUNT = document.getElementById("pluginCount");
+const STATIC_BROWSE = document.getElementById("staticBrowse");
+const PF_RESULTS = document.getElementById("pfResults");
+
+let staticCount = 0;
+
+async function loadStaticBrowse() {
+  const response = await fetch("plugins_list.html");
+  STATIC_BROWSE.innerHTML = await response.text();
+  staticCount = STATIC_BROWSE.querySelectorAll("a").length;
+  PLUGIN_COUNT.textContent = staticCount;
+}
+
+function setMode(searching) {
+  STATIC_BROWSE.style.display = searching ? "none" : "block";
+  PF_RESULTS.style.display = searching ? "block" : "none";
+  if (!searching) {
+    PLUGIN_COUNT.textContent = staticCount;
+  }
+}
+
+async function waitForInstance() {
+  while (
+    !window.PagefindComponents?.getInstanceManager?.()?.getInstance?.("default")
+  ) {
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return window.PagefindComponents.getInstanceManager().getInstance("default");
+}
+
+async function init() {
+  await loadStaticBrowse();
+  setMode(false);
+
+  let searching = false;
+  const instance = await waitForInstance();
+  instance.on("search", (term) => {
+    searching = (term ?? "").trim().length > 0;
+    setMode(searching);
+  });
+  instance.on("results", (searchResult) => {
+    // Only update the count while a search is active; when idle the static
+    // browse count is shown and the component may emit a hidden empty-search.
+    if (searching) {
+      PLUGIN_COUNT.textContent = searchResult?.results?.length ?? 0;
+    }
+  });
+}
+
+init();


### PR DESCRIPTION
# References and Relevant Issues

Closes #178 

# Description

After we introduced pagefind, our homepage is met with two problems:
1. there is a small load time for the WASM and such to finish for the default Pagefind query of the homepage of all plugins and
2. Pagefind _always_ returns results by **relevance** which is why the homepage sort changed.

This PR targets both solutions by:
1. Lazy loading pagefind by returning the pre-generated `plugins_list.html` which is date-sorted. This is the html that the old homepage used, so it's reverting to that behavior.
2. Using pagefind's relevance-sorted search results when searching...
3. This happens via the now `browse_toggle.js` running as a script on the page, which is actually quite readable considering I've never looked at js before. Basically, if we aren't searching do the `plugins_list.html` (homepage), otherwise go the pagefind route.

The reason the _homepage_ needs to be different is that pagefind can't return all results without a full API call, and it's `faceted` (default) homepage return can't be sorted. But we could address #39 still by add more `plugins_list_<sort>.html` and adding a toggle on them, but each list would be the 1.5MB that they are now (and growing). I'll open a PR to show the complexity that such a thing introduces for the `faceted` homepage.

Ultimately, this changes the behavior of search results to relevance from the old date-based, but I think that's better given now that we have fuzzy search, it's more important to bubble up the most relevant results. This also means long term we can continue to improve the relevance results and its a win in all contexts.
