### PR TITLE
[Demo] Sort all results by date rather than relevance

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,11 +74,14 @@
                         </div>
                         <div class="flex flex-auto items-center border-b-2 border-black text-xl"
                             data-testid="searchBarForm" id="searchBoxContainer">
-                                <link href="/pagefind/pagefind-component-ui.css" rel="stylesheet">
-                                <script src="/pagefind/pagefind-component-ui.js" type="module"></script>
-
-                                <pagefind-config faceted preload></pagefind-config>
-                                <pagefind-input placeholder="Search for a plugin by keyword or author" autofocus="true" class="w-full"></pagefind-input>
+                            <input type="text" id="searchBox" name="query"
+                                class="flex flex-auto border-none outline-none bg-transparent placeholder-gray-500 text-sds-body-s screen-495:text-sds-body-m w-0"
+                                placeholder="Search for a plugin by keyword or author"
+                                autofocus="true">
+                            <svg class="h-5 w-5 h-[1.375rem] w-[1.375rem]" fill="none" height="16" viewBox="0 0 16 16" width="16"
+                                xmlns="http://www.w3.org/2000/svg" id="searchIcon">
+                                <path d="M8.32004 7.68001L0.746704 15.2533M10.6667 9.60001C13.0134 9.60001 14.9334 7.68001 14.9334 5.33335C14.9334 2.98668 13.0134 1.06668 10.6667 1.06668C8.32004 1.06668 6.40004 2.98668 6.40004 5.33335C6.40004 7.68001 8.32004 9.60001 10.6667 9.60001Z" stroke="black" stroke-width="2"></path>
+                            </svg>
                         </div>
                     </div>
                 </div>
@@ -90,89 +93,11 @@
                         <section class="col-span-2 screen-1425:col-span-3 space-y-sds-xl">
                             <div class="flex justify-between">
                                 <h2 class="flex items-center font-bold text-xl">
-                                  Browse plugins: <span class="p-2" id="pluginCount">
-                                      <pagefind-summary class="flex items-center font-bold text-xl"></pagefind-summary>
-                                  </span>
+                                  Browse plugins: <span class="p-2" id="pluginCount"></span>
                                 </h2>
                             </div>
                             <div class="flex flex-col justify-center"
                                 id="pluginContainer">
-                                <pagefind-results>
-                                    <script type="text/pagefind-template">
-                                            <a class="searchResult py-sds-xl border-black border-t-2 last:border-b-2 hover:bg-hub-gray-100 w-full" data-testid="pluginSearchResult" href="{{ url | safeUrl }}">
-                                                <article class="grid gap-x-sds-xl screen-495:gap-x-12 screen-600:grid-cols-2 screen-1425:grid-cols-napari-3" data-testid="searchResult">
-                                                    <div class="col-span-2 screen-495:col-span-1 screen-1425:col-span-2 flex flex-col justify-between">
-                                                        <div>
-                                                            <h3 class="font-bold text-lg" data-testid="searchResultDisplayName">{{ meta.display_name }}</h3>
-                                                            <span class="mt-sds-m screen-495:mt-3 text-[0.6875rem]" data-testid="searchResultName">{{ meta.name }}</span>
-                                                            <p class="mt-3" data-testid="searchResultSummary">{{ meta.summary }}</p>
-                                                        </div>
-                                                        <div class="mt-3 text-xs">
-                                                            {{ meta.authors }}
-                                                        </div>
-                                                    </div>
-                                                    <ul class="mt-sds-l screen-600:m-0 space-y-1 text-sm col-span-2 screen-495:col-span-1">
-                                                        <li class="grid grid-cols-[auto,1fr]" data-label="First released" data-testid="searchResultMetadata" data-value="{{ meta.release_date }}">
-                                                            <h4 class="inline whitespace-nowrap">First released<!-- -->: </h4>
-                                                            {{#if meta.release_date}}
-                                                            <span class="ml-sds-xxs font-bold">{{ meta.release_date }}</span>
-                                                            {{:else}}
-                                                            <span class="ml-sds-xxs font-bold">Unknown</span>
-                                                            {{/if}}
-                                                        </li>
-                                                        <li class="grid grid-cols-[auto,1fr]" data-label="Last updated" data-testid="searchResultMetadata" data-value="{{ meta.last_updated }}">
-                                                            <h4 class="inline whitespace-nowrap">Last updated<!-- -->: </h4>
-                                                            {{#if meta.last_updated}}
-                                                            <span class="ml-sds-xxs font-bold">{{ meta.last_updated }}</span>
-                                                            {{:else}}
-                                                            <span class="ml-sds-xxs font-bold">Unknown</span>
-                                                            {{/if}}
-                                                        </li>
-                                                        <li class="grid grid-cols-[auto,1fr]" data-label="Plugin type" data-testid="searchResultMetadata" data-value="{{ meta.plugin_types }}">
-                                                            <h4 class="inline whitespace-nowrap">Plugin type<!-- -->: </h4>
-                                                            {{#if meta.plugin_types}}
-                                                            <span class="ml-sds-xxs font-bold">{{ meta.plugin_types | lowercase | replace(".", "") | trim }}</span>
-                                                            {{:else}}
-                                                            <span class="ml-sds-xxs font-bold">Unknown</span>
-                                                            {{/if}}
-                                                        </li>
-                                                    </ul>
-                                                    <div class="mt-sds-xl text-xs flex flex-col gap-sds-s col-span-2 screen-1425:col-span-3"></div>
-                                                </article>
-                                            </a>
-                                    </script>
-                                    <script type="text/pagefind-template" data-template="placeholder">
-                                            <a class="searchResult py-sds-xl border-black border-t-2 last:border-b-2 hover:bg-hub-gray-100 w-full opacity-30" data-testid="pluginSearchResult" href=".">
-                                                <article class="grid gap-x-sds-xl screen-495:gap-x-12 screen-600:grid-cols-2 screen-1425:grid-cols-napari-3" data-testid="searchResult">
-                                                    <div class="col-span-2 screen-495:col-span-1 screen-1425:col-span-2 flex flex-col justify-between">
-                                                        <div>
-                                                            <h3 class="font-bold text-lg" data-testid="searchResultDisplayName">...</h3>
-                                                            <span class="mt-sds-m screen-495:mt-3 text-[0.6875rem]" data-testid="searchResultName">...</span>
-                                                            <p class="mt-3" data-testid="searchResultSummary">...</p>
-                                                        </div>
-                                                        <div class="mt-3 text-xs">
-                                                            ...
-                                                        </div>
-                                                    </div>
-                                                    <ul class="mt-sds-l screen-600:m-0 space-y-1 text-sm col-span-2 screen-495:col-span-1">
-                                                        <li class="grid grid-cols-[auto,1fr]">
-                                                            <h4 class="inline whitespace-nowrap">First released<!-- -->: </h4>
-                                                            <span class="ml-sds-xxs font-bold">...</span>
-                                                        </li>
-                                                        <li class="grid grid-cols-[auto,1fr]">
-                                                            <h4 class="inline whitespace-nowrap">Last updated<!-- -->: </h4>
-                                                            <span class="ml-sds-xxs font-bold">...</span>
-                                                        </li>
-                                                        <li class="grid grid-cols-[auto,1fr]">
-                                                            <h4 class="inline whitespace-nowrap">Plugin type<!-- -->: </h4>
-                                                            <span class="ml-sds-xxs font-bold">...</span>
-                                                        </li>
-                                                    </ul>
-                                                    <div class="mt-sds-xl text-xs flex flex-col gap-sds-s col-span-2 screen-1425:col-span-3"></div>
-                                                </article>
-                                            </a>
-                                    </script>
-                                </pagefind-results>
                             </div>
                         </section>
                     </div>
@@ -203,6 +128,8 @@
             </div>
 
     </div>
+
+    <script type="module" src="/static/js/plugin_loading_and_search.js"></script>
 </body>
 
 </html>

--- a/static/js/plugin_loading_and_search.js
+++ b/static/js/plugin_loading_and_search.js
@@ -1,0 +1,197 @@
+/**
+ * Homepage plugin loading & search.
+ *
+ * The default "Browse plugins" section is the pre-generated `plugins_list.html`,
+ * which is sorted by `last_updated` (descending) so newly released/updated
+ * plugins appear at the top — restoring the pre-pagefind ordering. Searching
+ * uses Pagefind's fuzzy search via its JS API, also sorted by `last_updated`
+ * descending.
+ *
+ * See https://github.com/napari/hub-lite/issues/178.
+ *
+ * The sort key is registered on each plugin page via the
+ * `data-pagefind-sort="last_updated"` attribute in
+ * templates/each_plugin_template.html.
+ */
+
+const SEARCH_BOX = document.getElementById("searchBox");
+const PLUGIN_CONTAINER = document.getElementById("pluginContainer");
+const PLUGIN_COUNT = document.getElementById("pluginCount");
+
+const TIMEOUT_DURATION = 300; // debounce, ms
+const PLUGINS_LIST_URL = "plugins_list.html";
+const SORT = { last_updated: "desc" };
+
+let pagefind; // lazily loaded on the first search
+let searchTimeout;
+let currentSearchToken = 0;
+let staticHtml = null; // cached contents of plugins_list.html
+
+function escapeHtml(value) {
+  const entities = {
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    '"': "&quot;",
+    "'": "&#39;",
+  };
+  return String(value ?? "").replace(/[&<>"']/g, (char) => entities[char]);
+}
+
+function formatPluginTypes(pluginTypes) {
+  return String(pluginTypes ?? "").toLowerCase().replace(/\./g, "").trim();
+}
+
+function makeSpinner(text) {
+  const container = document.createElement("div");
+  container.className = "spinner-container";
+  const spinner = document.createElement("span");
+  spinner.className = "spinner";
+  const textNode = document.createElement("span");
+  textNode.textContent = text;
+  container.appendChild(spinner);
+  container.appendChild(textNode);
+  return container;
+}
+
+function renderResult({ url, meta }) {
+  const releaseDate = meta.release_date
+    ? escapeHtml(meta.release_date)
+    : "Unknown";
+  const lastUpdated = meta.last_updated
+    ? escapeHtml(meta.last_updated)
+    : "Unknown";
+  const pluginTypes = meta.plugin_types
+    ? escapeHtml(formatPluginTypes(meta.plugin_types))
+    : "Unknown";
+
+  return `
+  <a class="searchResult py-sds-xl border-black border-t-2 last:border-b-2 hover:bg-hub-gray-100 w-full" data-testid="pluginSearchResult" href="${escapeHtml(url)}">
+    <article class="grid gap-x-sds-xl screen-495:gap-x-12 screen-600:grid-cols-2 screen-1425:grid-cols-napari-3" data-testid="searchResult">
+      <div class="col-span-2 screen-495:col-span-1 screen-1425:col-span-2 flex flex-col justify-between">
+        <div>
+          <h3 class="font-bold text-lg" data-testid="searchResultDisplayName">${escapeHtml(meta.display_name)}</h3>
+          <span class="mt-sds-m screen-495:mt-3 text-[0.6875rem]" data-testid="searchResultName">${escapeHtml(meta.name)}</span>
+          <p class="mt-3" data-testid="searchResultSummary">${escapeHtml(meta.summary)}</p>
+        </div>
+        <div class="mt-3 text-xs">
+          ${escapeHtml(meta.authors)}
+        </div>
+      </div>
+      <ul class="mt-sds-l screen-600:m-0 space-y-1 text-sm col-span-2 screen-495:col-span-1">
+        <li class="grid grid-cols-[auto,1fr]" data-label="First released" data-testid="searchResultMetadata" data-value="${releaseDate}">
+          <h4 class="inline whitespace-nowrap">First released<!-- -->: </h4>
+          <span class="ml-sds-xxs font-bold">${releaseDate}</span>
+        </li>
+        <li class="grid grid-cols-[auto,1fr]" data-label="Last updated" data-testid="searchResultMetadata" data-value="${lastUpdated}">
+          <h4 class="inline whitespace-nowrap">Last updated<!-- -->: </h4>
+          <span class="ml-sds-xxs font-bold">${lastUpdated}</span>
+        </li>
+        <li class="grid grid-cols-[auto,1fr]" data-label="Plugin type" data-testid="searchResultMetadata" data-value="${pluginTypes}">
+          <h4 class="inline whitespace-nowrap">Plugin type<!-- -->: </h4>
+          <span class="ml-sds-xxs font-bold">${pluginTypes}</span>
+        </li>
+      </ul>
+      <div class="mt-sds-xl text-xs flex flex-col gap-sds-s col-span-2 screen-1425:col-span-3"></div>
+    </article>
+  </a>`;
+}
+
+function clearSearchSpinner() {
+  const searchBoxContainer = document.getElementById("searchBoxContainer");
+  const existingSpinner =
+    searchBoxContainer.querySelector(".spinner-container");
+  if (existingSpinner) {
+    searchBoxContainer.removeChild(existingSpinner);
+  }
+}
+
+async function loadStaticPlugins() {
+  // The default browse view is the pre-generated, updated-sorted list. It
+  // comes from a single static file, so it renders instantly with no blank/
+  // broken flash while Pagefind's WASM + index load lazily on first search.
+  if (staticHtml === null) {
+    const response = await fetch(PLUGINS_LIST_URL);
+    staticHtml = await response.text();
+  }
+  PLUGIN_CONTAINER.innerHTML = staticHtml;
+  PLUGIN_COUNT.textContent = PLUGIN_CONTAINER.querySelectorAll("a").length;
+}
+
+async function getPagefind() {
+  if (!pagefind) {
+    pagefind = await import("/pagefind/pagefind.js");
+    await pagefind.init();
+  }
+  return pagefind;
+}
+
+async function runSearch(searchText) {
+  const token = ++currentSearchToken;
+
+  // No query -> restore the full updated-sorted browse list.
+  if (!searchText.trim()) {
+    await loadStaticPlugins();
+    return;
+  }
+
+  clearSearchSpinner();
+  PLUGIN_CONTAINER.innerHTML = "";
+  const searchIcon = document.getElementById("searchIcon");
+  const searchBoxContainer = document.getElementById("searchBoxContainer");
+  searchBoxContainer.insertBefore(
+    makeSpinner("Searching plugins..."),
+    searchIcon,
+  );
+
+  try {
+    const pf = await getPagefind();
+    const search = await pf.search(searchText.trim(), { sort: SORT });
+    if (token !== currentSearchToken) return;
+
+    const results = search.results ?? [];
+    PLUGIN_COUNT.textContent = results.length;
+
+    const pluginData = await Promise.all(
+      results.map((result) => result.data()),
+    );
+    if (token !== currentSearchToken) return;
+
+    PLUGIN_CONTAINER.innerHTML = pluginData.map(renderResult).join("");
+  } finally {
+    if (token === currentSearchToken) {
+      clearSearchSpinner();
+    }
+  }
+}
+
+function attachSearchListener() {
+  SEARCH_BOX.addEventListener("input", () => {
+    clearTimeout(searchTimeout);
+    searchTimeout = setTimeout(
+      () => runSearch(SEARCH_BOX.value),
+      TIMEOUT_DURATION,
+    );
+  });
+}
+
+async function init() {
+  attachSearchListener();
+
+  // Default browse: the pre-generated, updated-sorted plugin list.
+  await loadStaticPlugins();
+
+  // Load Pagefind up front so search is ready as soon as the user types.
+  pagefind = await import("/pagefind/pagefind.js");
+  await pagefind.init();
+
+  // Support deep-linking to a search via ?query=...
+  const params = new URLSearchParams(window.location.search);
+  const query = params.get("query") ?? "";
+  if (query) {
+    SEARCH_BOX.value = query;
+    await runSearch(query);
+  }
+}
+
+init();

--- a/static/js/plugin_loading_and_search.js
+++ b/static/js/plugin_loading_and_search.js
@@ -178,12 +178,10 @@ function attachSearchListener() {
 async function init() {
   attachSearchListener();
 
-  // Default browse: the pre-generated, updated-sorted plugin list.
+  // Default browse: the pre-generated, updated-sorted plugin list. Pagefind
+  // is deliberately NOT loaded here — it is fetched lazily on the first
+  // search, so the homepage never blocks on the WASM/index bundle.
   await loadStaticPlugins();
-
-  // Load Pagefind up front so search is ready as soon as the user types.
-  pagefind = await import("/pagefind/pagefind.js");
-  await pagefind.init();
 
   // Support deep-linking to a search via ?query=...
   const params = new URLSearchParams(window.location.search);

--- a/templates/each_plugin_template.html
+++ b/templates/each_plugin_template.html
@@ -86,7 +86,7 @@
                                     <div class="">
                                         <p class="font-bold whitespace-nowrap">Last updated<!-- -->:</p>
                                         <ul class="MetadataList_list__3DlqI list-none text-sm leading-normal">
-                                            <li class="MetadataList_textItem__KKmMN" data-pagefind-meta="last_updated">${modified_at}</li>
+                                            <li class="MetadataList_textItem__KKmMN" data-pagefind-meta="last_updated" data-pagefind-sort="last_updated">${modified_at}</li>
                                         </ul>
                                     </div>
                                 </div>
@@ -94,7 +94,7 @@
                                     <div class="">
                                         <p class="font-bold whitespace-nowrap">First released<!-- -->:</p>
                                         <ul class="MetadataList_list__3DlqI list-none text-sm leading-normal">
-                                            <li class="MetadataList_textItem__KKmMN" data-pagefind-meta="release_date">${created_at}</li>
+                                            <li class="MetadataList_textItem__KKmMN" data-pagefind-meta="release_date" data-pagefind-sort="release_date">${created_at}</li>
                                         </ul>
                                     </div>
                                 </div>


### PR DESCRIPTION
# References and Relevant Issues

alternative to #180 
would also close #178 
implementation potential for #39 

# Description

_I do not think this is the route we should take. Such implementation adds complexity to this repo and require handcrafting all our results (like #39). This code is entirely LLM generated, which I feel would need to be the case given our expertise going forward._

This PR takes a very different approach to #180, and still accomplishes the same results expect for one change -- search results are _also_ sorted by date instead of relevance. As can be seen here this requires much more work:

1. we _completely_ get rid of the Pagefind component ui/results
2. we add in our custom sort algorithm that hijacks all the results by using a pagefind-defined sort order

This really goes to show why we don't want to _implicitly_ support alternative sort orders, at least on our own.
