### PR TITLE
Add sorting for search results

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,6 +93,12 @@
                                   Browse plugins: <span class="p-2" id="pluginCount"></span>
                                 </h2>
                             </div>
+                            <div id="sortControl" style="display:none" class="flex items-center gap-2">
+                                <span class="text-sm font-semibold mr-1">Sort:</span>
+                                <button type="button" data-sort-field="relevance" class="sort-btn active">Relevance</button>
+                                <button type="button" data-sort-field="last_updated" class="sort-btn">Last updated <span class="sort-arrow">▾</span></button>
+                                <button type="button" data-sort-field="first_released" class="sort-btn">First released <span class="sort-arrow">▾</span></button>
+                            </div>
                             <div class="flex flex-col justify-center"
                                 id="results">
                                 <p class="p-4">Loading plugins…</p>

--- a/static/css/all_plugins_styles.css
+++ b/static/css/all_plugins_styles.css
@@ -36,6 +36,27 @@ pagefind-summary {
     opacity: 0.3;
 }
 
+/* Sort toggle buttons (search results) */
+.sort-btn {
+    border: 2px solid black;
+    background: transparent;
+    padding: 0.25rem 0.75rem;
+    font-size: 0.875rem;
+    line-height: 1.25rem;
+    cursor: pointer;
+    color: black;
+}
+.sort-btn.active {
+    background: black;
+    color: white;
+}
+.sort-arrow {
+    visibility: hidden;
+}
+.sort-btn.active .sort-arrow {
+    visibility: visible;
+}
+
  .css-ngtr5k {
  padding: 0;
  }

--- a/static/js/browse.js
+++ b/static/js/browse.js
@@ -1,12 +1,15 @@
 /**
- * Homepage browse + search.
+ * Consolidated homepage search.
  *
  * - Browse (no query): the pre-generated `plugins_list.html`, sorted by
  *   `last_updated` descending, injected directly so the homepage is fast.
- * - Search: Pagefind's JS API (`pagefind.search(term)`). Results are rendered
- *   by filling the `<template id="plugin-card">` markup defined in
- *   `index.html`. Pagefind does all ranking; result sorting is added in a
- *   follow-up commit.
+ * - Search: Pagefind's JS API (`pagefind.search(term, { sort? })`). Results
+ *   are rendered by filling the `<template id="plugin-card">` markup defined
+ *   in `index.html`. Pagefind does all ranking/sorting; this file only wires
+ *   the search box, the "Sort" toggle buttons, and the card template.
+ *   The buttons let you sort results by "First released" or "Last updated"
+ *   (the same wording the plugin pages use), newest first (desc) or oldest
+ *   first (asc): clicking an active date button flips the direction.
  *
  * Pagefind is loaded lazily on the first search, so the homepage never blocks
  * on the WASM/index bundle.
@@ -15,16 +18,32 @@
 const SEARCH_BOX = document.getElementById("searchBox");
 const RESULTS = document.getElementById("results");
 const PLUGIN_COUNT = document.getElementById("pluginCount");
+const SORT_CONTROL = document.getElementById("sortControl");
+const SORT_BUTTONS = Array.from(
+  document.querySelectorAll("#sortControl .sort-btn"),
+);
 const PLUGIN_TEMPLATE = document.getElementById("plugin-card");
 
 const PLUGINS_LIST_URL = "plugins_list.html";
 const TIMEOUT_DURATION = 300;
+
+// Sort field/direction combos mapped to Pagefind `sort` payloads.
+// The "first_released" and "last_updated" keys are captured on every plugin
+// page via `data-pagefind-sort` in each_plugin_template.html.
+const SORT_OPTIONS = {
+  "first_released:desc": { first_released: "desc" },
+  "first_released:asc": { first_released: "asc" },
+  "last_updated:desc": { last_updated: "desc" },
+  "last_updated:asc": { last_updated: "asc" },
+};
 
 let pagefind; // lazily loaded on the first search
 let templateHtml = "";
 let staticHtml = null; // cached contents of plugins_list.html
 let searchTimeout;
 let currentToken = 0;
+let sortField = "relevance"; // "relevance" | "first_released" | "last_updated"
+let sortDir = "desc"; // only used when sortField is a date field
 
 function escapeHtml(value) {
   const entities = {
@@ -57,9 +76,7 @@ function fillTemplate(data) {
     )
     .replaceAll(
       "{{plugin_types}}",
-      escapeHtml(
-        data.plugin_types ? formatPluginTypes(data.plugin_types) : "Unknown",
-      ),
+      escapeHtml(data.plugin_types ? formatPluginTypes(data.plugin_types) : "Unknown"),
     )
     .replaceAll("{{url}}", escapeHtml(data.url));
 }
@@ -86,7 +103,10 @@ async function runSearch(searchText) {
   const term = (searchText ?? "").trim();
 
   const pf = await getPagefind();
-  const search = await pf.search(term);
+  const mode =
+    sortField === "relevance" ? "relevance" : `${sortField}:${sortDir}`;
+  const sort = SORT_OPTIONS[mode];
+  const search = await pf.search(term, sort ? { sort } : {});
   if (token !== currentToken) return;
 
   const results = search.results ?? [];
@@ -99,16 +119,55 @@ async function runSearch(searchText) {
     .join("");
 }
 
+function updateSortUI() {
+  SORT_BUTTONS.forEach((button) => {
+    const field = button.dataset.sortField;
+    const isActive = field === sortField;
+    button.classList.toggle("active", isActive);
+    const arrow = button.querySelector(".sort-arrow");
+    if (arrow) {
+      arrow.textContent = sortDir === "desc" ? "▾" : "▴";
+      arrow.classList.toggle("visible", isActive);
+    }
+  });
+}
+
 function attachListeners() {
   SEARCH_BOX.addEventListener("input", () => {
     clearTimeout(searchTimeout);
     searchTimeout = setTimeout(() => {
-      if (SEARCH_BOX.value.trim()) {
+      const searching = SEARCH_BOX.value.trim().length > 0;
+      SORT_CONTROL.style.display = searching ? "flex" : "none";
+      if (!searching) {
+        sortField = "relevance";
+        sortDir = "desc";
+        updateSortUI();
+      }
+      if (searching) {
         runSearch(SEARCH_BOX.value);
       } else {
         loadStaticBrowse();
       }
     }, TIMEOUT_DURATION);
+  });
+
+  SORT_BUTTONS.forEach((button) => {
+    button.addEventListener("click", () => {
+      const field = button.dataset.sortField;
+      if (field === sortField) {
+        if (field !== "relevance") {
+          // Re-clicking an active date button flips asc/desc.
+          sortDir = sortDir === "desc" ? "asc" : "desc";
+        }
+      } else {
+        sortField = field;
+        sortDir = "desc";
+      }
+      updateSortUI();
+      if (SEARCH_BOX.value.trim()) {
+        runSearch(SEARCH_BOX.value);
+      }
+    });
   });
 }
 

--- a/templates/each_plugin_template.html
+++ b/templates/each_plugin_template.html
@@ -86,7 +86,7 @@
                                     <div class="">
                                         <p class="font-bold whitespace-nowrap">Last updated<!-- -->:</p>
                                         <ul class="MetadataList_list__3DlqI list-none text-sm leading-normal">
-                                            <li class="MetadataList_textItem__KKmMN" data-pagefind-meta="last_updated">${modified_at}</li>
+                                            <li class="MetadataList_textItem__KKmMN" data-pagefind-meta="last_updated" data-pagefind-sort="last_updated">${modified_at}</li>
                                         </ul>
                                     </div>
                                 </div>
@@ -94,7 +94,7 @@
                                     <div class="">
                                         <p class="font-bold whitespace-nowrap">First released<!-- -->:</p>
                                         <ul class="MetadataList_list__3DlqI list-none text-sm leading-normal">
-                                            <li class="MetadataList_textItem__KKmMN" data-pagefind-meta="release_date">${created_at}</li>
+                                            <li class="MetadataList_textItem__KKmMN" data-pagefind-meta="release_date" data-pagefind-sort="first_released">${created_at}</li>
                                         </ul>
                                     </div>
                                 </div>


### PR DESCRIPTION
# References and Relevant Issues

Depends on #182 (stacked on `TimMonko:feat/homepage-search`, cool!).
Does not close #39 because this would require calling Pagefind into the homepage and sorting that way ... though I have ideas.

# Description

This adds sorting to the search results with some buttons that allow ascending/descending. The default search remains "relevance" but will now allow `last_updated` and `first_released`.

This is all out-of-the-box support with pagefind, so the changes here are about adding the implementation to the pages and updating our custom `browse.js` for the new fields (and simple css)