### PR TITLE
refactor: move result card markup into a <template>

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,6 +93,12 @@
                                   Browse plugins: <span class="p-2" id="pluginCount"></span>
                                 </h2>
                             </div>
+                            <div id="sortControl" style="display:none" class="flex items-center gap-2">
+                                <span class="text-sm font-semibold mr-1">Sort:</span>
+                                <button type="button" data-sort-field="relevance" class="sort-btn active">Relevance</button>
+                                <button type="button" data-sort-field="last_updated" class="sort-btn">Last updated <span class="sort-arrow">▾</span></button>
+                                <button type="button" data-sort-field="first_released" class="sort-btn">First released <span class="sort-arrow">▾</span></button>
+                            </div>
                             <div class="flex flex-col justify-center"
                                 id="results">
                                 <p class="p-4">Loading plugins…</p>

--- a/index.html
+++ b/index.html
@@ -74,11 +74,11 @@
                         </div>
                         <div class="flex flex-auto items-center border-b-2 border-black text-xl"
                             data-testid="searchBarForm" id="searchBoxContainer">
-                                <link href="/pagefind/pagefind-component-ui.css" rel="stylesheet">
-                                <script src="/pagefind/pagefind-component-ui.js" type="module"></script>
-
-                                <pagefind-config faceted preload></pagefind-config>
-                                <pagefind-input placeholder="Search for a plugin by keyword or author" autofocus="true" class="w-full"></pagefind-input>
+                            <input type="text" id="searchBox" name="query"
+                                class="flex flex-auto border-none outline-none bg-transparent placeholder-gray-500 text-sds-body-s screen-495:text-sds-body-m w-0"
+                                placeholder="Search for a plugin by keyword or author"
+                                autofocus="true">
+                            <img src="./static/images/search-icon.svg" alt="Search" class="h-5 w-5">
                         </div>
                     </div>
                 </div>
@@ -90,89 +90,12 @@
                         <section class="col-span-2 screen-1425:col-span-3 space-y-sds-xl">
                             <div class="flex justify-between">
                                 <h2 class="flex items-center font-bold text-xl">
-                                  Browse plugins: <span class="p-2" id="pluginCount">
-                                      <pagefind-summary class="flex items-center font-bold text-xl"></pagefind-summary>
-                                  </span>
+                                  Browse plugins: <span class="p-2" id="pluginCount"></span>
                                 </h2>
                             </div>
                             <div class="flex flex-col justify-center"
-                                id="pluginContainer">
-                                <pagefind-results>
-                                    <script type="text/pagefind-template">
-                                            <a class="searchResult py-sds-xl border-black border-t-2 last:border-b-2 hover:bg-hub-gray-100 w-full" data-testid="pluginSearchResult" href="{{ url | safeUrl }}">
-                                                <article class="grid gap-x-sds-xl screen-495:gap-x-12 screen-600:grid-cols-2 screen-1425:grid-cols-napari-3" data-testid="searchResult">
-                                                    <div class="col-span-2 screen-495:col-span-1 screen-1425:col-span-2 flex flex-col justify-between">
-                                                        <div>
-                                                            <h3 class="font-bold text-lg" data-testid="searchResultDisplayName">{{ meta.display_name }}</h3>
-                                                            <span class="mt-sds-m screen-495:mt-3 text-[0.6875rem]" data-testid="searchResultName">{{ meta.name }}</span>
-                                                            <p class="mt-3" data-testid="searchResultSummary">{{ meta.summary }}</p>
-                                                        </div>
-                                                        <div class="mt-3 text-xs">
-                                                            {{ meta.authors }}
-                                                        </div>
-                                                    </div>
-                                                    <ul class="mt-sds-l screen-600:m-0 space-y-1 text-sm col-span-2 screen-495:col-span-1">
-                                                        <li class="grid grid-cols-[auto,1fr]" data-label="First released" data-testid="searchResultMetadata" data-value="{{ meta.release_date }}">
-                                                            <h4 class="inline whitespace-nowrap">First released<!-- -->: </h4>
-                                                            {{#if meta.release_date}}
-                                                            <span class="ml-sds-xxs font-bold">{{ meta.release_date }}</span>
-                                                            {{:else}}
-                                                            <span class="ml-sds-xxs font-bold">Unknown</span>
-                                                            {{/if}}
-                                                        </li>
-                                                        <li class="grid grid-cols-[auto,1fr]" data-label="Last updated" data-testid="searchResultMetadata" data-value="{{ meta.last_updated }}">
-                                                            <h4 class="inline whitespace-nowrap">Last updated<!-- -->: </h4>
-                                                            {{#if meta.last_updated}}
-                                                            <span class="ml-sds-xxs font-bold">{{ meta.last_updated }}</span>
-                                                            {{:else}}
-                                                            <span class="ml-sds-xxs font-bold">Unknown</span>
-                                                            {{/if}}
-                                                        </li>
-                                                        <li class="grid grid-cols-[auto,1fr]" data-label="Plugin type" data-testid="searchResultMetadata" data-value="{{ meta.plugin_types }}">
-                                                            <h4 class="inline whitespace-nowrap">Plugin type<!-- -->: </h4>
-                                                            {{#if meta.plugin_types}}
-                                                            <span class="ml-sds-xxs font-bold">{{ meta.plugin_types | lowercase | replace(".", "") | trim }}</span>
-                                                            {{:else}}
-                                                            <span class="ml-sds-xxs font-bold">Unknown</span>
-                                                            {{/if}}
-                                                        </li>
-                                                    </ul>
-                                                    <div class="mt-sds-xl text-xs flex flex-col gap-sds-s col-span-2 screen-1425:col-span-3"></div>
-                                                </article>
-                                            </a>
-                                    </script>
-                                    <script type="text/pagefind-template" data-template="placeholder">
-                                            <a class="searchResult py-sds-xl border-black border-t-2 last:border-b-2 hover:bg-hub-gray-100 w-full opacity-30" data-testid="pluginSearchResult" href=".">
-                                                <article class="grid gap-x-sds-xl screen-495:gap-x-12 screen-600:grid-cols-2 screen-1425:grid-cols-napari-3" data-testid="searchResult">
-                                                    <div class="col-span-2 screen-495:col-span-1 screen-1425:col-span-2 flex flex-col justify-between">
-                                                        <div>
-                                                            <h3 class="font-bold text-lg" data-testid="searchResultDisplayName">...</h3>
-                                                            <span class="mt-sds-m screen-495:mt-3 text-[0.6875rem]" data-testid="searchResultName">...</span>
-                                                            <p class="mt-3" data-testid="searchResultSummary">...</p>
-                                                        </div>
-                                                        <div class="mt-3 text-xs">
-                                                            ...
-                                                        </div>
-                                                    </div>
-                                                    <ul class="mt-sds-l screen-600:m-0 space-y-1 text-sm col-span-2 screen-495:col-span-1">
-                                                        <li class="grid grid-cols-[auto,1fr]">
-                                                            <h4 class="inline whitespace-nowrap">First released<!-- -->: </h4>
-                                                            <span class="ml-sds-xxs font-bold">...</span>
-                                                        </li>
-                                                        <li class="grid grid-cols-[auto,1fr]">
-                                                            <h4 class="inline whitespace-nowrap">Last updated<!-- -->: </h4>
-                                                            <span class="ml-sds-xxs font-bold">...</span>
-                                                        </li>
-                                                        <li class="grid grid-cols-[auto,1fr]">
-                                                            <h4 class="inline whitespace-nowrap">Plugin type<!-- -->: </h4>
-                                                            <span class="ml-sds-xxs font-bold">...</span>
-                                                        </li>
-                                                    </ul>
-                                                    <div class="mt-sds-xl text-xs flex flex-col gap-sds-s col-span-2 screen-1425:col-span-3"></div>
-                                                </article>
-                                            </a>
-                                    </script>
-                                </pagefind-results>
+                                id="results">
+                                <p class="p-4">Loading plugins…</p>
                             </div>
                         </section>
                     </div>
@@ -203,6 +126,8 @@
             </div>
 
     </div>
+
+    <script type="module" src="./static/js/browse.js"></script>
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -103,6 +103,36 @@
                                 id="results">
                                 <p class="p-4">Loading plugins…</p>
                             </div>
+
+                            <template id="plugin-card">
+                                <a class="searchResult py-sds-xl border-black border-t-2 last:border-b-2 hover:bg-hub-gray-100 w-full" data-testid="pluginSearchResult" href="{{url}}">
+                                    <article class="grid gap-x-sds-xl screen-495:gap-x-12 screen-600:grid-cols-2 screen-1425:grid-cols-napari-3" data-testid="searchResult">
+                                        <div class="col-span-2 screen-495:col-span-1 screen-1425:col-span-2 flex flex-col justify-between">
+                                            <div>
+                                                <h3 class="font-bold text-lg" data-testid="searchResultDisplayName">{{display_name}}</h3>
+                                                <span class="mt-sds-m screen-495:mt-3 text-[0.6875rem]" data-testid="searchResultName">{{name}}</span>
+                                                <p class="mt-3" data-testid="searchResultSummary">{{summary}}</p>
+                                            </div>
+                                            <div class="mt-3 text-xs">{{authors}}</div>
+                                        </div>
+                                        <ul class="mt-sds-l screen-600:m-0 space-y-1 text-sm col-span-2 screen-495:col-span-1">
+                                            <li class="grid grid-cols-[auto,1fr]" data-label="First released" data-testid="searchResultMetadata" data-value="{{release_date}}">
+                                                <h4 class="inline whitespace-nowrap">First released: </h4>
+                                                <span class="ml-sds-xxs font-bold">{{release_date}}</span>
+                                            </li>
+                                            <li class="grid grid-cols-[auto,1fr]" data-label="Last updated" data-testid="searchResultMetadata" data-value="{{last_updated}}">
+                                                <h4 class="inline whitespace-nowrap">Last updated: </h4>
+                                                <span class="ml-sds-xxs font-bold">{{last_updated}}</span>
+                                            </li>
+                                            <li class="grid grid-cols-[auto,1fr]" data-label="Plugin type" data-testid="searchResultMetadata" data-value="{{plugin_types}}">
+                                                <h4 class="inline whitespace-nowrap">Plugin type: </h4>
+                                                <span class="ml-sds-xxs font-bold">{{plugin_types}}</span>
+                                            </li>
+                                        </ul>
+                                        <div class="mt-sds-xl text-xs flex flex-col gap-sds-s col-span-2 screen-1425:col-span-3"></div>
+                                    </article>
+                                </a>
+                            </template>
                         </section>
                     </div>
                 </div>

--- a/static/css/all_plugins_styles.css
+++ b/static/css/all_plugins_styles.css
@@ -36,6 +36,27 @@ pagefind-summary {
     opacity: 0.3;
 }
 
+/* Sort toggle buttons (search results) */
+.sort-btn {
+    border: 2px solid black;
+    background: transparent;
+    padding: 0.25rem 0.75rem;
+    font-size: 0.875rem;
+    line-height: 1.25rem;
+    cursor: pointer;
+    color: black;
+}
+.sort-btn.active {
+    background: black;
+    color: white;
+}
+.sort-arrow {
+    visibility: hidden;
+}
+.sort-btn.active .sort-arrow {
+    visibility: visible;
+}
+
  .css-ngtr5k {
  padding: 0;
  }

--- a/static/js/browse.js
+++ b/static/js/browse.js
@@ -1,0 +1,149 @@
+/**
+ * Homepage browse + search.
+ *
+ * - Browse (no query): the pre-generated `plugins_list.html`, sorted by
+ *   `last_updated` descending, injected directly so the homepage is fast.
+ * - Search: Pagefind's JS API (`pagefind.search(term)`). Results are rendered
+ *   by filling the card markup below. (Follow-up commits add sorting and move
+ *   this markup into a `<template id="plugin-card">` in `index.html`.)
+ *
+ * Pagefind is loaded lazily on the first search, so the homepage never blocks
+ * on the WASM/index bundle.
+ */
+
+const SEARCH_BOX = document.getElementById("searchBox");
+const RESULTS = document.getElementById("results");
+const PLUGIN_COUNT = document.getElementById("pluginCount");
+
+const PLUGINS_LIST_URL = "plugins_list.html";
+const TIMEOUT_DURATION = 300;
+
+// Result card markup, kept here as a string for now (a later commit moves it
+// into a <template id="plugin-card"> element in index.html).
+const CARD_TEMPLATE = `
+<a class="searchResult py-sds-xl border-black border-t-2 last:border-b-2 hover:bg-hub-gray-100 w-full" data-testid="pluginSearchResult" href="{{url}}">
+  <article class="grid gap-x-sds-xl screen-495:gap-x-12 screen-600:grid-cols-2 screen-1425:grid-cols-napari-3" data-testid="searchResult">
+    <div class="col-span-2 screen-495:col-span-1 screen-1425:col-span-2 flex flex-col justify-between">
+      <div>
+        <h3 class="font-bold text-lg" data-testid="searchResultDisplayName">{{display_name}}</h3>
+        <span class="mt-sds-m screen-495:mt-3 text-[0.6875rem]" data-testid="searchResultName">{{name}}</span>
+        <p class="mt-3" data-testid="searchResultSummary">{{summary}}</p>
+      </div>
+      <div class="mt-3 text-xs">{{authors}}</div>
+    </div>
+    <ul class="mt-sds-l screen-600:m-0 space-y-1 text-sm col-span-2 screen-495:col-span-1">
+      <li class="grid grid-cols-[auto,1fr]" data-label="First released" data-testid="searchResultMetadata" data-value="{{release_date}}">
+        <h4 class="inline whitespace-nowrap">First released: </h4>
+        <span class="ml-sds-xxs font-bold">{{release_date}}</span>
+      </li>
+      <li class="grid grid-cols-[auto,1fr]" data-label="Last updated" data-testid="searchResultMetadata" data-value="{{last_updated}}">
+        <h4 class="inline whitespace-nowrap">Last updated: </h4>
+        <span class="ml-sds-xxs font-bold">{{last_updated}}</span>
+      </li>
+      <li class="grid grid-cols-[auto,1fr]" data-label="Plugin type" data-testid="searchResultMetadata" data-value="{{plugin_types}}">
+        <h4 class="inline whitespace-nowrap">Plugin type: </h4>
+        <span class="ml-sds-xxs font-bold">{{plugin_types}}</span>
+      </li>
+    </ul>
+    <div class="mt-sds-xl text-xs flex flex-col gap-sds-s col-span-2 screen-1425:col-span-3"></div>
+  </article>
+</a>
+`;
+
+let pagefind; // lazily loaded on the first search
+let staticHtml = null; // cached contents of plugins_list.html
+let searchTimeout;
+let currentToken = 0;
+
+function escapeHtml(value) {
+  const entities = {
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    '"': "&quot;",
+    "'": "&#39;",
+  };
+  return String(value ?? "").replace(/[&<>"']/g, (char) => entities[char]);
+}
+
+function formatPluginTypes(pluginTypes) {
+  return String(pluginTypes ?? "").toLowerCase().replace(/\./g, "").trim();
+}
+
+function fillTemplate(data) {
+  return CARD_TEMPLATE
+    .replaceAll("{{display_name}}", escapeHtml(data.display_name))
+    .replaceAll("{{name}}", escapeHtml(data.name))
+    .replaceAll("{{summary}}", escapeHtml(data.summary))
+    .replaceAll("{{authors}}", escapeHtml(data.authors))
+    .replaceAll(
+      "{{release_date}}",
+      escapeHtml(data.release_date || "Unknown"),
+    )
+    .replaceAll(
+      "{{last_updated}}",
+      escapeHtml(data.last_updated || "Unknown"),
+    )
+    .replaceAll(
+      "{{plugin_types}}",
+      escapeHtml(
+        data.plugin_types ? formatPluginTypes(data.plugin_types) : "Unknown",
+      ),
+    )
+    .replaceAll("{{url}}", escapeHtml(data.url));
+}
+
+async function loadStaticBrowse() {
+  if (staticHtml === null) {
+    const response = await fetch(PLUGINS_LIST_URL);
+    staticHtml = await response.text();
+  }
+  RESULTS.innerHTML = staticHtml;
+  PLUGIN_COUNT.textContent = RESULTS.querySelectorAll("a").length;
+}
+
+async function getPagefind() {
+  if (!pagefind) {
+    pagefind = await import("/pagefind/pagefind.js");
+    await pagefind.init();
+  }
+  return pagefind;
+}
+
+async function runSearch(searchText) {
+  const token = ++currentToken;
+  const term = (searchText ?? "").trim();
+
+  const pf = await getPagefind();
+  const search = await pf.search(term);
+  if (token !== currentToken) return;
+
+  const results = search.results ?? [];
+  PLUGIN_COUNT.textContent = results.length;
+  const pluginData = await Promise.all(results.map((result) => result.data()));
+  if (token !== currentToken) return;
+
+  RESULTS.innerHTML = pluginData
+    .map((data) => fillTemplate({ url: data.url, ...data.meta }))
+    .join("");
+}
+
+function attachListeners() {
+  SEARCH_BOX.addEventListener("input", () => {
+    clearTimeout(searchTimeout);
+    searchTimeout = setTimeout(() => {
+      if (SEARCH_BOX.value.trim()) {
+        runSearch(SEARCH_BOX.value);
+      } else {
+        loadStaticBrowse();
+      }
+    }, TIMEOUT_DURATION);
+  });
+}
+
+async function init() {
+  attachListeners();
+  await loadStaticBrowse();
+}
+
+init();

--- a/static/js/browse.js
+++ b/static/js/browse.js
@@ -1,13 +1,15 @@
 /**
- * Homepage browse + search, with sortable results.
+ * Consolidated homepage search.
  *
  * - Browse (no query): the pre-generated `plugins_list.html`, sorted by
  *   `last_updated` descending, injected directly so the homepage is fast.
  * - Search: Pagefind's JS API (`pagefind.search(term, { sort? })`). Results
- *   are rendered by filling the card markup below. A segmented sort control
- *   orders results by relevance, "Last updated", or "First released" (the
- *   same wording the plugin pages use), newest first (desc) or oldest first
- *   (asc): clicking an active date button flips the direction.
+ *   are rendered by filling the `<template id="plugin-card">` markup defined
+ *   in `index.html`. Pagefind does all ranking/sorting; this file only wires
+ *   the search box, the "Sort" toggle buttons, and the card template.
+ *   The buttons let you sort results by "First released" or "Last updated"
+ *   (the same wording the plugin pages use), newest first (desc) or oldest
+ *   first (asc): clicking an active date button flips the direction.
  *
  * Pagefind is loaded lazily on the first search, so the homepage never blocks
  * on the WASM/index bundle.
@@ -20,6 +22,7 @@ const SORT_CONTROL = document.getElementById("sortControl");
 const SORT_BUTTONS = Array.from(
   document.querySelectorAll("#sortControl .sort-btn"),
 );
+const PLUGIN_TEMPLATE = document.getElementById("plugin-card");
 
 const PLUGINS_LIST_URL = "plugins_list.html";
 const TIMEOUT_DURATION = 300;
@@ -34,39 +37,8 @@ const SORT_OPTIONS = {
   "last_updated:asc": { last_updated: "asc" },
 };
 
-// Result card markup, kept here as a string for now (a later commit moves it
-// into a <template id="plugin-card"> element in index.html).
-const CARD_TEMPLATE = `
-<a class="searchResult py-sds-xl border-black border-t-2 last:border-b-2 hover:bg-hub-gray-100 w-full" data-testid="pluginSearchResult" href="{{url}}">
-  <article class="grid gap-x-sds-xl screen-495:gap-x-12 screen-600:grid-cols-2 screen-1425:grid-cols-napari-3" data-testid="searchResult">
-    <div class="col-span-2 screen-495:col-span-1 screen-1425:col-span-2 flex flex-col justify-between">
-      <div>
-        <h3 class="font-bold text-lg" data-testid="searchResultDisplayName">{{display_name}}</h3>
-        <span class="mt-sds-m screen-495:mt-3 text-[0.6875rem]" data-testid="searchResultName">{{name}}</span>
-        <p class="mt-3" data-testid="searchResultSummary">{{summary}}</p>
-      </div>
-      <div class="mt-3 text-xs">{{authors}}</div>
-    </div>
-    <ul class="mt-sds-l screen-600:m-0 space-y-1 text-sm col-span-2 screen-495:col-span-1">
-      <li class="grid grid-cols-[auto,1fr]" data-label="First released" data-testid="searchResultMetadata" data-value="{{release_date}}">
-        <h4 class="inline whitespace-nowrap">First released: </h4>
-        <span class="ml-sds-xxs font-bold">{{release_date}}</span>
-      </li>
-      <li class="grid grid-cols-[auto,1fr]" data-label="Last updated" data-testid="searchResultMetadata" data-value="{{last_updated}}">
-        <h4 class="inline whitespace-nowrap">Last updated: </h4>
-        <span class="ml-sds-xxs font-bold">{{last_updated}}</span>
-      </li>
-      <li class="grid grid-cols-[auto,1fr]" data-label="Plugin type" data-testid="searchResultMetadata" data-value="{{plugin_types}}">
-        <h4 class="inline whitespace-nowrap">Plugin type: </h4>
-        <span class="ml-sds-xxs font-bold">{{plugin_types}}</span>
-      </li>
-    </ul>
-    <div class="mt-sds-xl text-xs flex flex-col gap-sds-s col-span-2 screen-1425:col-span-3"></div>
-  </article>
-</a>
-`;
-
 let pagefind; // lazily loaded on the first search
+let templateHtml = "";
 let staticHtml = null; // cached contents of plugins_list.html
 let searchTimeout;
 let currentToken = 0;
@@ -89,7 +61,7 @@ function formatPluginTypes(pluginTypes) {
 }
 
 function fillTemplate(data) {
-  return CARD_TEMPLATE
+  return templateHtml
     .replaceAll("{{display_name}}", escapeHtml(data.display_name))
     .replaceAll("{{name}}", escapeHtml(data.name))
     .replaceAll("{{summary}}", escapeHtml(data.summary))
@@ -104,9 +76,7 @@ function fillTemplate(data) {
     )
     .replaceAll(
       "{{plugin_types}}",
-      escapeHtml(
-        data.plugin_types ? formatPluginTypes(data.plugin_types) : "Unknown",
-      ),
+      escapeHtml(data.plugin_types ? formatPluginTypes(data.plugin_types) : "Unknown"),
     )
     .replaceAll("{{url}}", escapeHtml(data.url));
 }
@@ -202,6 +172,7 @@ function attachListeners() {
 }
 
 async function init() {
+  templateHtml = PLUGIN_TEMPLATE.innerHTML;
   attachListeners();
   await loadStaticBrowse();
 }

--- a/static/js/browse.js
+++ b/static/js/browse.js
@@ -1,11 +1,13 @@
 /**
- * Homepage browse + search.
+ * Homepage browse + search, with sortable results.
  *
  * - Browse (no query): the pre-generated `plugins_list.html`, sorted by
  *   `last_updated` descending, injected directly so the homepage is fast.
- * - Search: Pagefind's JS API (`pagefind.search(term)`). Results are rendered
- *   by filling the card markup below. (Follow-up commits add sorting and move
- *   this markup into a `<template id="plugin-card">` in `index.html`.)
+ * - Search: Pagefind's JS API (`pagefind.search(term, { sort? })`). Results
+ *   are rendered by filling the card markup below. A segmented sort control
+ *   orders results by relevance, "Last updated", or "First released" (the
+ *   same wording the plugin pages use), newest first (desc) or oldest first
+ *   (asc): clicking an active date button flips the direction.
  *
  * Pagefind is loaded lazily on the first search, so the homepage never blocks
  * on the WASM/index bundle.
@@ -14,9 +16,23 @@
 const SEARCH_BOX = document.getElementById("searchBox");
 const RESULTS = document.getElementById("results");
 const PLUGIN_COUNT = document.getElementById("pluginCount");
+const SORT_CONTROL = document.getElementById("sortControl");
+const SORT_BUTTONS = Array.from(
+  document.querySelectorAll("#sortControl .sort-btn"),
+);
 
 const PLUGINS_LIST_URL = "plugins_list.html";
 const TIMEOUT_DURATION = 300;
+
+// Sort field/direction combos mapped to Pagefind `sort` payloads.
+// The "first_released" and "last_updated" keys are captured on every plugin
+// page via `data-pagefind-sort` in each_plugin_template.html.
+const SORT_OPTIONS = {
+  "first_released:desc": { first_released: "desc" },
+  "first_released:asc": { first_released: "asc" },
+  "last_updated:desc": { last_updated: "desc" },
+  "last_updated:asc": { last_updated: "asc" },
+};
 
 // Result card markup, kept here as a string for now (a later commit moves it
 // into a <template id="plugin-card"> element in index.html).
@@ -54,6 +70,8 @@ let pagefind; // lazily loaded on the first search
 let staticHtml = null; // cached contents of plugins_list.html
 let searchTimeout;
 let currentToken = 0;
+let sortField = "relevance"; // "relevance" | "first_released" | "last_updated"
+let sortDir = "desc"; // only used when sortField is a date field
 
 function escapeHtml(value) {
   const entities = {
@@ -115,7 +133,10 @@ async function runSearch(searchText) {
   const term = (searchText ?? "").trim();
 
   const pf = await getPagefind();
-  const search = await pf.search(term);
+  const mode =
+    sortField === "relevance" ? "relevance" : `${sortField}:${sortDir}`;
+  const sort = SORT_OPTIONS[mode];
+  const search = await pf.search(term, sort ? { sort } : {});
   if (token !== currentToken) return;
 
   const results = search.results ?? [];
@@ -128,16 +149,55 @@ async function runSearch(searchText) {
     .join("");
 }
 
+function updateSortUI() {
+  SORT_BUTTONS.forEach((button) => {
+    const field = button.dataset.sortField;
+    const isActive = field === sortField;
+    button.classList.toggle("active", isActive);
+    const arrow = button.querySelector(".sort-arrow");
+    if (arrow) {
+      arrow.textContent = sortDir === "desc" ? "▾" : "▴";
+      arrow.classList.toggle("visible", isActive);
+    }
+  });
+}
+
 function attachListeners() {
   SEARCH_BOX.addEventListener("input", () => {
     clearTimeout(searchTimeout);
     searchTimeout = setTimeout(() => {
-      if (SEARCH_BOX.value.trim()) {
+      const searching = SEARCH_BOX.value.trim().length > 0;
+      SORT_CONTROL.style.display = searching ? "flex" : "none";
+      if (!searching) {
+        sortField = "relevance";
+        sortDir = "desc";
+        updateSortUI();
+      }
+      if (searching) {
         runSearch(SEARCH_BOX.value);
       } else {
         loadStaticBrowse();
       }
     }, TIMEOUT_DURATION);
+  });
+
+  SORT_BUTTONS.forEach((button) => {
+    button.addEventListener("click", () => {
+      const field = button.dataset.sortField;
+      if (field === sortField) {
+        if (field !== "relevance") {
+          // Re-clicking an active date button flips asc/desc.
+          sortDir = sortDir === "desc" ? "asc" : "desc";
+        }
+      } else {
+        sortField = field;
+        sortDir = "desc";
+      }
+      updateSortUI();
+      if (SEARCH_BOX.value.trim()) {
+        runSearch(SEARCH_BOX.value);
+      }
+    });
   });
 }
 

--- a/templates/each_plugin_template.html
+++ b/templates/each_plugin_template.html
@@ -86,7 +86,7 @@
                                     <div class="">
                                         <p class="font-bold whitespace-nowrap">Last updated<!-- -->:</p>
                                         <ul class="MetadataList_list__3DlqI list-none text-sm leading-normal">
-                                            <li class="MetadataList_textItem__KKmMN" data-pagefind-meta="last_updated">${modified_at}</li>
+                                            <li class="MetadataList_textItem__KKmMN" data-pagefind-meta="last_updated" data-pagefind-sort="last_updated">${modified_at}</li>
                                         </ul>
                                     </div>
                                 </div>
@@ -94,7 +94,7 @@
                                     <div class="">
                                         <p class="font-bold whitespace-nowrap">First released<!-- -->:</p>
                                         <ul class="MetadataList_list__3DlqI list-none text-sm leading-normal">
-                                            <li class="MetadataList_textItem__KKmMN" data-pagefind-meta="release_date">${created_at}</li>
+                                            <li class="MetadataList_textItem__KKmMN" data-pagefind-meta="release_date" data-pagefind-sort="first_released">${created_at}</li>
                                         </ul>
                                     </div>
                                 </div>


### PR DESCRIPTION
:robot: *Human guided, AI assisted PR ([using this skill](https://github.com/henryiii/skills/blob/main/branch-and-pr/SKILL.md)). AI text below.* :robot:

## Summary
Move the result card markup from a template string inside `browse.js` into a `<template id=plugin-card>` element in `index.html`, so the card markup lives in a single place in the HTML.

Depends on #182 and #183 (stacked; this branch's base is `feat/sort-search-results`).

## Changes
- `index.html`: add `<template id=plugin-card>` containing the card markup
- `static/js/browse.js`: read the template's `innerHTML` instead of the `CARD_TEMPLATE` string (`fillTemplate` is otherwise unchanged)

## Test plan
Built locally; verified search results render identically to before, with no console errors.

Assisted-by: GitHub Copilot:DeepSeek V4 Flash